### PR TITLE
Add id selector site-content

### DIFF
--- a/src/js/xray.js
+++ b/src/js/xray.js
@@ -89,10 +89,18 @@ $(function() {
             preArticleExtractor: function() {
             },
             articleExtractor: function() {
-                // replace the entire app's content with just the article
-                const article = $('article#story');
                 const app = $('div#app');
-                app.html(article);
+                const article = $('article#story');
+                const content = $('main#site-content');
+                const isArticle = article.length > 0;
+                const isContent = content.length > 0;
+
+                // replace the entire app's content with just the article
+                if (isArticle) {
+                    app.html(article);
+                } else if (isContent) {
+                    app.html(content);
+                }
             }
         },
         'www.theepochtimes.com': {


### PR DESCRIPTION
### Goals

Individual pieces in NYTimes use 'article' as tag and 'story' as id. However, the home page, live news, covid news and others use 'main' tags and 'site-content' as ids. When users try to access these pages, the id selector `article` would return an empty object. The current code would render a blank page as a result of replacing the entire app's content with an empty element (length = 0).

### Changes

It seems that NYTimes uses either 'article#story' or 'main#site-content'. This PR adds an additional ID selector for the latter and only replace the app's content when we have the element.

### Before vs. After

1. www.nytimes.com
<img width="1330" alt="Screen Shot 2020-12-29 at 4 04 23 PM" src="https://user-images.githubusercontent.com/31831596/103323305-29aebf80-49f7-11eb-9daa-c91188bd16fb.png">

<img width="1320" alt="Screen Shot 2020-12-29 at 4 05 55 PM" src="https://user-images.githubusercontent.com/31831596/103323319-39c69f00-49f7-11eb-80e3-e479c9469e18.png">

2. https://www.nytimes.com/live/2020/12/29/us/joe-biden-trump

<img width="1317" alt="Screen Shot 2020-12-29 at 4 04 57 PM" src="https://user-images.githubusercontent.com/31831596/103323331-421eda00-49f7-11eb-9b09-b71b193babfe.png">

<img width="1319" alt="Screen Shot 2020-12-29 at 4 06 25 PM" src="https://user-images.githubusercontent.com/31831596/103323360-58c53100-49f7-11eb-9b0c-5c6266bd9d57.png">

3. Covid series: https://www.nytimes.com/live/2020/12/29/world/covid-19-coronavirus-updates?name=styln-coronavirus&region=TOP_BANNER&block=storyline_menu_recirc&action=click&pgtype=LegacyCollection&impression_id=8313cd81-4a34-11eb-8899-7929376e4828&variant=1_Show

<img width="1259" alt="Screen Shot 2020-12-29 at 5 09 24 PM" src="https://user-images.githubusercontent.com/31831596/103323628-a55d3c00-49f8-11eb-8138-7eab504ea9b6.png">

<img width="1325" alt="Screen Shot 2020-12-29 at 4 18 46 PM" src="https://user-images.githubusercontent.com/31831596/103323355-52cf5000-49f7-11eb-9d03-6a61cadb3118.png">

### How to test

- Clone the branch, try it against the master branch on the above links 

### Caveats && To-Do

- The current code would not render the navigation bar on the home page. This could be fixed in a different PR.
